### PR TITLE
Update CI workflow to include boost-libs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             git unzip jre-openjdk \
             ghc cabal-install haskell-shake haskell-aeson-pretty \
             cmake extra-cmake-modules ninja \
-            fmt boost \
+            fmt boost boost-libs \
             python opencc \
             gperf
 


### PR DESCRIPTION
libboost_iostreams now is in boost-libs, without it, CI will fail

for detail, please check this build [log](https://github.com/MokOopsing/f5a-prebuilder/actions/runs/24766371809/job/72461493467)

And there are the package contents for boost-libs: https://archlinux.org/packages/extra/x86_64/boost-libs/

